### PR TITLE
Use an empty string as default for empty Package properties.

### DIFF
--- a/src/com/tw/pkg/deb/repo/DebianRepository.java
+++ b/src/com/tw/pkg/deb/repo/DebianRepository.java
@@ -139,7 +139,13 @@ public class DebianRepository {
             } else {
                 String parts[] = line.split(": ");
                 String data = parts[0];
-                String value = parts[1];
+                //Set a default value of empty sting for cases where no value is provided,
+                //such as empty Source: with custom packages
+                String value = "";
+                if (parts.length > 1) {
+                    value = parts[1];
+                }
+                
 
                 if (data.equalsIgnoreCase("Package")) {
                     debPkg.setName(value);


### PR DESCRIPTION
Often when rolling packages with tools like FPM, the Source: value may be empty.
This causes an ArrayIndexOutOfBoundsException.  Setting a default of an empty
string will avoid this condition.

closes #2
